### PR TITLE
Adding hv flavor for HPE AMD dl345

### DIFF
--- a/openstack/ironic/templates/seed.yaml
+++ b/openstack/ironic/templates/seed.yaml
@@ -541,6 +541,18 @@ spec:
       "resources:CUSTOM_BM_S16_C16_M8192_V0": "1"
       {{- tuple . "baremetal" | include "ironic.helpers.extra_specs" | indent 6 }}
 
+  # new HPE proliant dl345 AMD server
+  - name: "hv_s1_c72_m1152_v0"
+    id: "2041"
+    vcpus: 72
+    ram: 1179648
+    disk: 447
+    is_public: false
+    extra_specs:
+      "catalog:description": Hypervisor 1 socket, 72 cores, 1152GB RAM, AMD EPYC
+      "resources:CUSTOM_HV_S1_C72_M1152_V0": "1"
+      {{- tuple . "baremetal" | include "ironic.helpers.extra_specs" | indent 6 }}
+
   domains:
   - name: Default
     users:


### PR DESCRIPTION
Sockets: 1
Cores: 72
RAM: 1152 GB
Disk Size: 447 GB
e.g.: https://netbox.global.cloud.sap/dcim/devices/46435/